### PR TITLE
feature: 1~9 사이의 서로 다른 임의의 3자리 숫자 생성

### DIFF
--- a/src/main/java/baseball/BaseballComputer.java
+++ b/src/main/java/baseball/BaseballComputer.java
@@ -1,6 +1,28 @@
 package baseball;
 
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+
+import camp.nextstep.edu.missionutils.Randoms;
+
 /* 1에서 9까지 서로 다른 임의의 수 3개의 숫자 생성 */
 public class BaseballComputer {
+	// 컴퓨터 숫자 세자리 생성
+	public String createComputerNumbers() {
+		HashSet<Integer> computerNumbers = pickComputerNumbers();
+		StringBuilder str = new StringBuilder();
+		for (Integer computerNumber : computerNumbers) {
+			str.append(computerNumber);
+		}
+		return str.toString();
+	}
 
+	// 랜덤으로 1~9까지의 숫자 생성
+	private HashSet<Integer> pickComputerNumbers() {
+		HashSet<Integer> computerNumbers = new LinkedHashSet<>(); // 중복 방지용 hashset
+		while (computerNumbers.size() < 3) {
+			computerNumbers.add(Randoms.pickNumberInRange(1, 9));
+		}
+		return computerNumbers;
+	}
 }

--- a/src/main/java/baseball/BaseballComputer.java
+++ b/src/main/java/baseball/BaseballComputer.java
@@ -1,0 +1,6 @@
+package baseball;
+
+/* 1에서 9까지 서로 다른 임의의 수 3개의 숫자 생성 */
+public class BaseballComputer {
+
+}

--- a/src/main/java/baseball/BaseballComputer.java
+++ b/src/main/java/baseball/BaseballComputer.java
@@ -7,7 +7,7 @@ import camp.nextstep.edu.missionutils.Randoms;
 
 /* 1에서 9까지 서로 다른 임의의 수 3개의 숫자 생성 */
 public class BaseballComputer {
-	// 컴퓨터 숫자 세자리 생성
+	// HashSet<Integer> 타입을 String 타입으로 변환 (숫자 게임에 사용)
 	public String createComputerNumbers() {
 		HashSet<Integer> computerNumbers = pickComputerNumbers();
 		StringBuilder str = new StringBuilder();
@@ -17,7 +17,7 @@ public class BaseballComputer {
 		return str.toString();
 	}
 
-	// 랜덤으로 1~9까지의 숫자 생성
+	// 랜덤으로 1~9 사이의 임의의 숫자 생성 (중복 x)
 	private HashSet<Integer> pickComputerNumbers() {
 		HashSet<Integer> computerNumbers = new LinkedHashSet<>(); // 중복 방지용 hashset
 		while (computerNumbers.size() < 3) {

--- a/src/main/java/baseball/BaseballUmpire.java
+++ b/src/main/java/baseball/BaseballUmpire.java
@@ -1,0 +1,6 @@
+package baseball;
+
+/* 플레이어가 제시한 숫자를 판정하고 결과를 반환 */
+public class BaseballUmpire {
+
+}


### PR DESCRIPTION
## 변경 사항
### feat: 1~9 사이의 서로 다른 임의의 3자리 숫자 생성
#### 1. 랜덤으로 1~9 사이의 임의의 숫자 생성 (중복 x)
- `LinkedHashSet<T>` 타입을 사용하여 숫자 중복을 방지.
- `Randoms.pickNumberInRange(startInclusive, endInclusive)` 메서드를 사용하여 난수 생성.
```java
private HashSet<Integer> pickComputerNumbers() {
	HashSet<Integer> computerNumbers = new LinkedHashSet<>(); // 중복 방지용 hashset
	while (computerNumbers.size() < 3) {
		computerNumbers.add(Randoms.pickNumberInRange(1, 9));
	}
	return computerNumbers;
}
```

#### 2. HashSet<Integer> 타입을 String 타입으로 변환 (숫자 게임에 사용)
- 앞에서 생성한 `computerNumbers`를 한 개씩 붙여서 `String` 타입으로 변환.
- `StringBuilder.append()`를 사용하고, 반환 시에는 `toString()`을 사용해 형변환.
```java
public String createComputerNumbers() {
	HashSet<Integer> computerNumbers = pickComputerNumbers();
	StringBuilder str = new StringBuilder();
	for (Integer computerNumber : computerNumbers) {
		str.append(computerNumber);
	}
	return str.toString();
}
```

## 실행 결과
![image](https://github.com/jungeun5-choi/java-baseball-6/assets/119802267/6ed8a196-ca2e-400c-b663-5c412d67c9fc)

